### PR TITLE
#4 Creates the DualGeneralizedPlant and GeneralizedSubPlant types

### DIFF
--- a/src/SystemLevelControl.jl
+++ b/src/SystemLevelControl.jl
@@ -7,7 +7,7 @@ module SystemLevelControl
 # --
 
 export AbstractFeedbackStructure, StateFeedback, OutputFeedback
-export AbstractGeneralizedPlant, GeneralizedPlant, Plant
+export AbstractGeneralizedPlant, GeneralizedPlant, DualGeneralizedPlant, Plant
 export SLS_𝓗₂
 export sparsity_dim_reduction
 export generateTree

--- a/src/SystemLevelControl.jl
+++ b/src/SystemLevelControl.jl
@@ -7,7 +7,7 @@ module SystemLevelControl
 # --
 
 export AbstractFeedbackStructure, StateFeedback, OutputFeedback
-export AbstractGeneralizedPlant, GeneralizedPlant, DualGeneralizedPlant, Plant
+export AbstractGeneralizedPlant, GeneralizedPlant, DualGeneralizedPlant, GeneralizedSubPlant, Plant
 export SLS_𝓗₂
 export sparsity_dim_reduction
 export generateTree

--- a/src/types/GeneralizedPlant.jl
+++ b/src/types/GeneralizedPlant.jl
@@ -109,25 +109,62 @@ Plant(args...; kwargs...) = GeneralizedPlant(args...; kwargs...)
 # SPECIAL AUXILIARY TYPES ______________________________________________________
 struct DualGeneralizedPlant{T,Ts} <: AbstractGeneralizedPlant{T,Ts}
     # Fields
-    parent::GeneralizedPlant{T,Ts}
-    A::Adjoint{T, SparseMatrixCSC{T,Int}}
-    B₁::Adjoint{T, SparseMatrixCSC{T,Int}}
-    B₂::Adjoint{T, SparseMatrixCSC{T,Int}}
-    C₁::Adjoint{T, SparseMatrixCSC{T,Int}}
-    D₁₁::Adjoint{T, SparseMatrixCSC{T,Int}}
-    D₁₂::Adjoint{T, SparseMatrixCSC{T,Int}}
-    C₂::Adjoint{T, SparseMatrixCSC{T,Int}}
-    D₂₁::Adjoint{T, SparseMatrixCSC{T,Int}}
-    D₂₂::Adjoint{T, SparseMatrixCSC{T,Int}}
+    parent::AbstractGeneralizedPlant{T,Ts}
+    A::Adjoint
+    B₁::Adjoint
+    B₂::Adjoint
+    C₁::Adjoint
+    D₁₁::Adjoint
+    D₁₂::Adjoint
+    C₂::Adjoint
+    D₂₁::Adjoint
+    D₂₂::Adjoint
     Nx::Integer; Nz::Integer; Ny::Integer; Nw::Integer; Nu::Integer;
 
     # Explicit constructors
-    function DualGeneralizedPlant{T,Ts}(P::GeneralizedPlant{T,Ts}) where {T<:Number,Ts<:OutputFeedback}
+    function DualGeneralizedPlant{T,Ts}(P::AbstractGeneralizedPlant{T,Ts}) where {T<:Number,Ts<:OutputFeedback}
         new{T,Ts}(P, P.A', P.C₁', P.C₂', P.B₁', P.D₁₁', P.D₂₁', P.B₂', P.D₁₂', P.D₂₂', P.Nx, P.Nw, P.Nu, P.Nz, P.Ny)
     end
 
-    function DualGeneralizedPlant{T,Ts}(P::GeneralizedPlant{T,Ts}) where {T<:Number,Ts<:StateFeedback}
+    function DualGeneralizedPlant{T,Ts}(P::AbstractGeneralizedPlant{T,Ts}) where {T<:Number,Ts<:StateFeedback}
         new{T,Ts}(P, P.A', P.C₁', P.C₂', P.B₁', P.D₁₁', spzeros(size(P.B₁))', P.B₂', P.D₁₂', spzeros(size(P.B₂))', P.Nx, P.Nw, P.Nu, P.Nz, P.Ny)
+    end
+end
+
+struct GeneralizedSubPlant{T,Ts} <: AbstractGeneralizedPlant{T,Ts}
+    # Fields
+    parent::AbstractGeneralizedPlant{T,Ts}
+    A::SubArray
+    B₁::SubArray
+    B₂::SubArray
+    C₁::SubArray
+    D₁₁::SubArray
+    D₁₂::SubArray
+    C₂::SubArray
+    D₂₁::SubArray
+    D₂₂::SubArray
+    Nx::Integer; Nz::Integer; Ny::Integer; Nw::Integer; Nu::Integer;
+
+    # Explicit constructors
+    function GeneralizedSubPlant{T,Ts}(P::AbstractGeneralizedPlant{T,Ts},I::Tuple,J::Tuple) where {T<:Number,Ts<:AbstractFeedbackStructure}
+        A = view(P.A, I[1], J[1])  
+        B₁ = view(P.B₁, I[1], J[2])   
+        B₂ = view(P.B₂, I[1], J[3])
+        C₁ = view(P.C₁, I[2], J[1])
+        D₁₁ = view(P.D₁₁, I[2], J[2]) 
+        D₁₂ = view(P.D₁₂, I[2], J[3])
+        
+        if Ts <: StateFeedback
+            C₂ = view(P.C₂, I[1], J[1])
+            D₂₁ = view(P.D₂₁, :, J[2])
+            D₂₂ = view(P.D₂₂, :, J[3])
+        else 
+            C₂ = view(P.C₂, I[3], J[1])
+            D₂₁ = view(P.D₂₁, I[3], J[2])
+            D₂₂ = view(P.D₂₂, I[3], J[3])
+        end
+        
+        new{T,Ts}(P, A, B₁, B₂, C₁, D₁₁, D₁₂, C₂, D₂₁, D₂₂, size(A,1), size(C₁,1), size(C₂,1), size(B₁,2), size(B₂,2))
     end
 end
 

--- a/src/types/GeneralizedPlant.jl
+++ b/src/types/GeneralizedPlant.jl
@@ -106,6 +106,31 @@ end
 Plant(args...; kwargs...) = GeneralizedPlant(args...; kwargs...)
 
 
+# SPECIAL AUXILIARY TYPES ______________________________________________________
+struct DualGeneralizedPlant{T,Ts} <: AbstractGeneralizedPlant{T,Ts}
+    # Fields
+    parent::GeneralizedPlant{T,Ts}
+    A::Adjoint{T, SparseMatrixCSC{T,Int}}
+    B₁::Adjoint{T, SparseMatrixCSC{T,Int}}
+    B₂::Adjoint{T, SparseMatrixCSC{T,Int}}
+    C₁::Adjoint{T, SparseMatrixCSC{T,Int}}
+    D₁₁::Adjoint{T, SparseMatrixCSC{T,Int}}
+    D₁₂::Adjoint{T, SparseMatrixCSC{T,Int}}
+    C₂::Adjoint{T, SparseMatrixCSC{T,Int}}
+    D₂₁::Adjoint{T, SparseMatrixCSC{T,Int}}
+    D₂₂::Adjoint{T, SparseMatrixCSC{T,Int}}
+    Nx::Integer; Nz::Integer; Ny::Integer; Nw::Integer; Nu::Integer;
+
+    # Explicit constructors
+    function DualGeneralizedPlant{T,Ts}(P::GeneralizedPlant{T,Ts}) where {T<:Number,Ts<:OutputFeedback}
+        new{T,Ts}(P, P.A', P.C₁', P.C₂', P.B₁', P.D₁₁', P.D₂₁', P.B₂', P.D₁₂', P.D₂₂', P.Nx, P.Nw, P.Nu, P.Nz, P.Ny)
+    end
+
+    function DualGeneralizedPlant{T,Ts}(P::GeneralizedPlant{T,Ts}) where {T<:Number,Ts<:StateFeedback}
+        new{T,Ts}(P, P.A', P.C₁', P.C₂', P.B₁', P.D₁₁', spzeros(size(P.B₁))', P.B₂', P.D₁₂', spzeros(size(P.B₂))', P.Nx, P.Nw, P.Nu, P.Nz, P.Ny)
+    end
+end
+
 # VALIDATIONS AND AUXILIARY FUNCTIONS __________________________________________
 Base.show(io::IO, P::AbstractGeneralizedPlant) = print(io, "$(size(P,1))×$(size(P,2)) $(typeof(P)) w/ $(P.Nx) states, $(P.Ny) outputs, $(P.Nu) controls.")
 

--- a/src/types/operations.jl
+++ b/src/types/operations.jl
@@ -16,7 +16,7 @@ function Base.:(==)(P1::AbstractGeneralizedPlant, P2::AbstractGeneralizedPlant)
 end
 
 Base.:size(P::AbstractGeneralizedPlant) = (P.Nx+P.Nz+P.Ny, P.Nx+P.Nu+P.Nw);
-Base.:size(P::AbstractGeneralizedPlant, i::Int) = (P.Nx+P.Nz+P.Ny, P.Nu+P.Nw)[i];
+Base.:size(P::AbstractGeneralizedPlant, i::Int) = (P.Nx+P.Nz+P.Ny, P.Nx+P.Nu+P.Nw)[i];
 Base.:ndims(P::AbstractGeneralizedPlant) = 2;
 
 # Overloads the iterate() interface to unpack the system matrices

--- a/src/types/operations.jl
+++ b/src/types/operations.jl
@@ -7,6 +7,7 @@
 ##  and their specialized subtypes
 
 # PLANT OPERATIONS __________________________________________________________
+@inline
 function Base.:(==)(P1::AbstractGeneralizedPlant, P2::AbstractGeneralizedPlant)
     if P1 isa GeneralizedPlant && P2 isa GeneralizedPlant   # This avoids elementwise comparison in adjoint arrays
         return all(getfield(P1,f)==getfield(P2,f) for f in fieldnames(GeneralizedPlant))
@@ -33,9 +34,11 @@ Base.:iterate(P::AbstractGeneralizedPlant, ::Val{:done}) = return nothing;
 
 # System/Block algebra
 Base.:adjoint(P::AbstractGeneralizedPlant{T,Ts}) where {T,Ts} = DualGeneralizedPlant{T,Ts}(P)
-Base.:adjoint(P::DualGeneralizedPlant{T,Ts}) where {T,Ts} = P.parent
+Base.:adjoint(P::DualGeneralizedPlant) = P.parent
 
 Base.:view(P::AbstractGeneralizedPlant{T,Ts}, I::Tuple, J::Tuple) where {T,Ts} = GeneralizedSubPlant{T,Ts}(P,I,J)
+
+Base.:copy(P::AbstractGeneralizedPlant) = Plant(P.A,P.B₁,P.B₂,P.C₁,P.D₁₁,P.D₁₂,P.C₂,P.D₂₁,P.D₂₂)
 
 @inline
 function Base.:getindex(P::AbstractGeneralizedPlant{T,Ts}, I::Tuple, J::Tuple) where {T,Ts}
@@ -48,5 +51,7 @@ function Base.:getindex(P::AbstractGeneralizedPlant{T,Ts}, I::Tuple, J::Tuple) w
                      P.C₂[I[3],J[1]], P.D₂₁[I[3],J[2]], P.D₂₂[I[3],J[3]])
     end
 end
+
+
 
 # ___________________________________________________________________________

--- a/src/types/operations.jl
+++ b/src/types/operations.jl
@@ -37,4 +37,16 @@ Base.:adjoint(P::DualGeneralizedPlant{T,Ts}) where {T,Ts} = P.parent
 
 Base.:view(P::AbstractGeneralizedPlant{T,Ts}, I::Tuple, J::Tuple) where {T,Ts} = GeneralizedSubPlant{T,Ts}(P,I,J)
 
+@inline
+function Base.:getindex(P::AbstractGeneralizedPlant{T,Ts}, I::Tuple, J::Tuple) where {T,Ts}
+    if Ts <: StateFeedback
+        return Plant(P.A[I[1],J[1]], P.B₁[I[1],J[2]], P.B₂[I[1],J[3]],
+                     P.C₁[I[2],J[1]], P.D₁₁[I[2],J[2]], P.D₁₂[I[2],J[3]])
+    else
+        return Plant(P.A[I[1],J[1]], P.B₁[I[1],J[2]], P.B₂[I[1],J[3]],
+                     P.C₁[I[2],J[1]], P.D₁₁[I[2],J[2]], P.D₁₂[I[2],J[3]],
+                     P.C₂[I[3],J[1]], P.D₂₁[I[3],J[2]], P.D₂₂[I[3],J[3]])
+    end
+end
+
 # ___________________________________________________________________________

--- a/src/types/operations.jl
+++ b/src/types/operations.jl
@@ -8,10 +8,10 @@
 
 # PLANT OPERATIONS __________________________________________________________
 function Base.:(==)(P1::AbstractGeneralizedPlant, P2::AbstractGeneralizedPlant)
-    if P1 isa DualGeneralizedPlant || P2 isa DualGeneralizedPlant   # This avoids elementwise comparison in adjoint arrays
-        return all(norm(getfield(P1,f)-getfield(P2,f)) <= eps() for f in fieldnames(GeneralizedPlant)[1:9])
+    if P1 isa GeneralizedPlant && P2 isa GeneralizedPlant   # This avoids elementwise comparison in adjoint arrays
+        return all(getfield(P1,f)==getfield(P2,f) for f in fieldnames(GeneralizedPlant))
     else 
-        return all(getfield(P1,f)==getfield(P2,f) for f in fieldnames(GeneralizedPlant)[1:9])
+        return all(norm(getfield(P1,f)-getfield(P2,f)) <= eps() for f in fieldnames(GeneralizedPlant)[1:9])
     end
 end
 
@@ -32,7 +32,9 @@ Base.:iterate(P::AbstractGeneralizedPlant, ::Val{:D₂₂}) = return (P.D₂₂,
 Base.:iterate(P::AbstractGeneralizedPlant, ::Val{:done}) = return nothing;
 
 # System/Block algebra
-Base.:adjoint(P::GeneralizedPlant{T,Ts}) where {T,Ts} = DualGeneralizedPlant{T,Ts}(P)
+Base.:adjoint(P::AbstractGeneralizedPlant{T,Ts}) where {T,Ts} = DualGeneralizedPlant{T,Ts}(P)
 Base.:adjoint(P::DualGeneralizedPlant{T,Ts}) where {T,Ts} = P.parent
+
+Base.:view(P::AbstractGeneralizedPlant{T,Ts}, I::Tuple, J::Tuple) where {T,Ts} = GeneralizedSubPlant{T,Ts}(P,I,J)
 
 # ___________________________________________________________________________

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using Test, SafeTestsets
 
 @time begin 
     @time @safetestset "(Types) GeneralizedPlant composite type" begin include("types_GeneralizedPlant_test.jl") end
+    @time @safetestset "(Types) Operations on AbstractGeneralizedPlants" begin include("types_operations_test.jl") end
     #
     @time @safetestset "dimensionality reduction methods" begin include("reduction_test.jl") end
 end

--- a/test/types_operations_test.jl
+++ b/test/types_operations_test.jl
@@ -1,0 +1,32 @@
+# -----------------------------------------------------------------------
+## Copyright (C) 2023- by Otacilio 'Minho' Neto, <otacilio.neto@aalto.fi>
+# This code is part of the 'SystemLevelControl.jl' package, licensed
+# the MIT License (see <https://spdx.org/licenses/MIT.html> )                
+# -----------------------------------------------------------------------
+using SystemLevelControl, Test 
+using LinearAlgebra, SparseArrays
+# --
+
+## Sparse large-scale systems ___________________________________________
+Nx,Nu,Nw,Ny = (100000, 52000, 51000, 50000)
+A = sprandn(Nx, Nx, 1/Nx);
+B₁ = sprandn(Nx, Nw, 1/Nw);
+B₂ = sprandn(Nx, Nu, 1/Nu);
+
+C₁ = sprandn(Nx+Nu, Nx, 1/Nx);
+D₁₁ = sprandn(Nx+Nu, Nw, 1/Nw);
+D₁₂ = sprandn(Nx+Nu, Nu, 1/Nu);
+
+C₂ = sprandn(Ny, Nx, 1/Nx);
+D₂₁ = sprandn(Ny, Nw, 1/Nw);
+D₂₂ = sprandn(Ny, Nu, 1/Nu);
+
+P_large = Plant(A, B₁, B₂, C₁, D₁₁, D₁₂, C₂, D₂₁, D₂₂)
+P_large_adjoint = Plant(A', C₁', C₂', B₁', D₁₁', D₂₁', B₂', D₁₂', D₂₂')
+
+P_large_dual = DualGeneralizedPlant{Float64,OutputFeedback}(P_large);
+
+@test P_large === (P_large')'
+@test P_large_adjoint == P_large'
+@test P_large_dual == P_large'
+@test P_large_dual == P_large_adjoint

--- a/test/types_operations_test.jl
+++ b/test/types_operations_test.jl
@@ -30,3 +30,15 @@ P_large_dual = DualGeneralizedPlant{Float64,OutputFeedback}(P_large);
 @test P_large_adjoint == P_large'
 @test P_large_dual == P_large'
 @test P_large_dual == P_large_adjoint
+
+## Sparse large-scale state-feedback systems ____________________________
+P_SF_large = Plant(A, B₁, B₂, C₁, D₁₁, D₁₂)
+P_SF_large_adjoint = Plant(A', C₁', I(Nx), B₁', D₁₁', spzeros(Nw,Nx), B₂', D₁₂', spzeros(Nu,Nx))
+
+P_SF_large_dual = DualGeneralizedPlant{Float64,StateFeedback}(P_SF_large);
+
+@test P_SF_large === (P_SF_large')'
+@test P_SF_large_adjoint == P_SF_large'
+@test P_SF_large_dual == P_SF_large'
+@test P_SF_large_dual == P_SF_large_adjoint
+

--- a/test/types_operations_test.jl
+++ b/test/types_operations_test.jl
@@ -63,6 +63,9 @@ P_large_subsystem = @inferred GeneralizedSubPlant{Float64,OutputFeedback}(P_larg
 
 @test P_large_slice == P_large[II,JJ]
 
+@test P_large_subsystem !== copy(P_large_subsystem)
+@test P_large_subsystem == copy(P_large_subsystem)
+
 @test view(P_large, II, JJ) isa GeneralizedSubPlant{Float64,OutputFeedback}
 @test P_large[II,JJ] isa GeneralizedPlant{Float64,OutputFeedback}
 
@@ -82,6 +85,9 @@ P_SF_large_subsystem = @inferred GeneralizedSubPlant{Float64,StateFeedback}(P_SF
 
 @test P_SF_large_slice == P_SF_large[II,JJ]
 
+@test P_SF_large_subsystem !== copy(P_SF_large_subsystem)
+@test P_SF_large_subsystem == copy(P_SF_large_subsystem)
+
 @test view(P_SF_large, II, JJ) isa GeneralizedSubPlant{Float64,StateFeedback}
 @test P_SF_large[II,JJ] isa GeneralizedPlant{Float64,StateFeedback}
 
@@ -99,5 +105,28 @@ P_SF_large_subsystem = @inferred GeneralizedSubPlant{Float64,StateFeedback}(P_SF
 
 @test P_SF_large_slice == P_SF_large[II,JJ]
 
+@test P_SF_large_subsystem !== copy(P_SF_large_subsystem)
+@test P_SF_large_subsystem == copy(P_SF_large_subsystem)
+
 @test view(P_SF_large, II, JJ) isa GeneralizedSubPlant{Float64,StateFeedback}
 @test P_SF_large[II,JJ] isa GeneralizedPlant{Float64,StateFeedback}
+
+## NESTED OPERATIONS __________________________________________
+## Sparse large-scale systems _________________________________
+II = (1:2000, [1:500; 900:1200], :);
+JJ = (1:2000, 1, [1; 3; 6]);
+
+P_large = Plant(A, B₁, B₂, C₁, D₁₁, D₁₂, C₂, D₂₁, D₂₂)
+P_large_adjoint_subsystem = Plant(A'[II[1],JJ[1]], C₁'[II[1],JJ[2]], C₂'[II[1],JJ[3]], 
+                                  B₁'[II[2],JJ[1]], D₁₁'[II[2],JJ[2]], D₂₁'[II[2],JJ[3]], 
+                                  B₂'[II[3],JJ[1]], D₁₂'[II[3],JJ[2]], D₂₂'[II[3],JJ[3]])
+
+@test P_large_adjoint_subsystem == view(P_large', II, JJ)
+@test P_large_adjoint_subsystem == P_large'[II,JJ]
+
+P_large_subsystem_adjoint = Plant(A[II[1],JJ[1]]', C₁[II[2],JJ[1]]', C₂[II[3],JJ[1]]', 
+                                  B₁[II[1],JJ[2]]', D₁₁[II[2],JJ[2]]', D₂₁[II[3],JJ[2]]', 
+                                  B₂[II[1],JJ[3]]', D₁₂[II[2],JJ[3]]', D₂₂[II[3],JJ[3]]')
+
+@test P_large_subsystem_adjoint == view(P_large, II, JJ)'
+@test P_large_subsystem_adjoint == P_large[II,JJ]'


### PR DESCRIPTION
Solving issue #4, this merge introduces the datatypes `DualGeneralizedPlant` and `GeneralizedSubPlant` and their associated methods. Specifically:

- An adjoint/dual plant can be obtained through the `adjoint(P)` function (or `P'` using the transpose operator).
- A subsystem can be extracted from a plant either by `view(P, I, J)` (non-allocating) or simply `P[I,J]`, where `I` and `J` are tuples of appropriate sizes for slicing the outputs and inputs. 
